### PR TITLE
Support p12

### DIFF
--- a/lib/mind_meld.rb
+++ b/lib/mind_meld.rb
@@ -25,7 +25,7 @@ class MindMeld
         @http.ca_file = options[:ca_file] if options.key?(:ca_file)
         @http.verify_mode = options[:verify_mode] if options.key?(:verify_mode)
       elsif options.key?(:pem) and options[:pem]
-        warn "["DEPRECATION"] Key [:pem] is deprecated in Mind Meld. Use [:cert] instead."
+        warn "['DEPRECATION'] Key [:pem] is deprecated in Mind Meld. Use [:cert] instead."
         pem = File.read(options[:pem])
         @http.cert = OpenSSL::X509::Certificate.new(pem)
         @http.key = OpenSSL::PKey::RSA.new(pem)

--- a/lib/mind_meld.rb
+++ b/lib/mind_meld.rb
@@ -9,11 +9,27 @@ class MindMeld
     if options[:url]
       uri = URI.parse(options[:url])
       @http = Net::HTTP.new(uri.host, uri.port)
-      if options.key?(:pem) and options[:pem]
-        pem = File.read(options[:pem])
+      
+      if options.key?(:cert) and options[:cert]
+        type = options[:cert].split('/').last.split('.').last == "p12" ? "p12" : "pem" 
+        if type == "pem" 
+          pem = File.read(options[:cert])
+          @http.cert = OpenSSL::X509::Certificate.new(pem)
+          @http.key = OpenSSL::PKey::RSA.new(pem)
+        elsif type == "p12" 
+          p12 = OpenSSL::PKCS12.new(File.binread(options[:cert]))
+          @http.cert = p12.certificate
+          @http.key = p12.key
+        end
         @http.use_ssl = true if uri.scheme == 'https'
+        @http.ca_file = options[:ca_file] if options.key?(:ca_file)
+        @http.verify_mode = options[:verify_mode] if options.key?(:verify_mode)
+      elsif options.key?(:pem) and options[:pem]
+        warn "["DEPRECATION"] Key [:pem] is deprecated in Mind Meld. Use [:cert] instead."
+        pem = File.read(options[:pem])
         @http.cert = OpenSSL::X509::Certificate.new(pem)
         @http.key = OpenSSL::PKey::RSA.new(pem)
+        @http.use_ssl = true if uri.scheme == 'https'
         @http.ca_file = options[:ca_file] if options.key?(:ca_file)
         @http.verify_mode = options[:verify_mode] if options.key?(:verify_mode)
       end

--- a/mind_meld.gemspec
+++ b/mind_meld.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'mind_meld'
-  s.version = '0.1.10'
+  s.version = '0.1.11'
   s.date = Time.now.strftime("%Y-%m-%d")
   s.summary = 'API for Hive Mind'
   s.description = 'API for Hive Mind'


### PR DESCRIPTION
1. When creating mind_meld object we now need to pass in [:cert] key instead of [:pem].
2. Depending on the extension of the cert file (pem or p12) it will create http object and return.
3. There is still support to [:pem] key which shows deprecation warning. 
